### PR TITLE
Add package dependencies needed for the AWS server 

### DIFF
--- a/.ebextensions/01_packages.config
+++ b/.ebextensions/01_packages.config
@@ -1,0 +1,5 @@
+packages:
+  yum:
+    python3-devel: []
+    mariadb-devel: []
+    gcc: []

--- a/.ebextensions/db-migrate.config
+++ b/.ebextensions/db-migrate.config
@@ -1,2 +1,8 @@
-
+container_commands:
+  01_migrate:
+    command: "source /var/app/venv/*/bin/activate && python3 manage.py migrate"
+    leader_only: true
+option_settings:
+  aws:elasticbeanstalk:application:environment:
+    DJANGO_SETTINGS_MODULE: DeliveryDetectorServer.settings
 

--- a/api_call.py
+++ b/api_call.py
@@ -4,7 +4,7 @@ import requests
 # The device will be making various API calls to the server 
 class DeliveryDetectorBox():
 
-    # Constructor 
+    # Constructor       
     def __init__(self, box_num):
         self.box_number = box_num
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2
 pytz==2021.3
 sqlparse==0.4.2
-
+mysqlclient==2.0.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2
 pytz==2021.3
 sqlparse==0.4.2
-mysqlclient==2.0.3
+
 


### PR DESCRIPTION
The package dependencies are needed for successful deployment to the AWS server. The dependencies are for mysqlclient which is a required package for communicating with the database. 